### PR TITLE
Fix project name in "Contributing" section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ BeatmapSetExtended set = client.endpoints.getBeatmapSet(842412).get();
 
 ## Contributing
 
-Thanks for your interest in contributing to CheckStyle! Please see the
+Thanks for your interest in contributing to Jospi! Please see the
 [Contribution Guidelines](https://github.com/wyvrtn/jospi/blob/master/CONTRIBUTING.md)
 for information on how to contribute to the project. This includes creating issues, submitting pull
 requests, and setting up your development environment.


### PR DESCRIPTION
# General Description

This PR changes the name "CheckStyle" to "Jospi" in the Contributing section of the README.md file. This is a critical issue that needs fixing, as it may confuse contributors about what project they are contributing to, as the contributing section of the README does not align with the rest of the project.

## All Submissions

- [x] Have you followed the guidelines in our [Contributing](https://github.com/wyvrtn/jospi/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
